### PR TITLE
Don't stop scrolling on the first round that adds no results

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,6 +23,12 @@ class Place:
     opens_at: str = ""
     introduction: str = ""
 
+# Google lazy-loads the results panel, so a scroll that adds nothing is not
+# proof the list ended — it usually means the next batch is still in flight.
+# Only give up after this many flat rounds, waiting between each.
+MAX_STAGNANT_SCROLLS = 3
+SCROLL_SETTLE_MS = 1000
+
 def setup_logging():
     logging.basicConfig(
         level=logging.INFO,
@@ -126,16 +132,25 @@ def scrape_places(search_for: str, total: int) -> List[Place]:
             page.wait_for_selector('//a[contains(@href, "https://www.google.com/maps/place")]')
             page.hover('//a[contains(@href, "https://www.google.com/maps/place")]')
             previously_counted = 0
+            stagnant_rounds = 0
             while True:
                 page.mouse.wheel(0, 10000)
                 page.wait_for_selector('//a[contains(@href, "https://www.google.com/maps/place")]')
                 found = page.locator('//a[contains(@href, "https://www.google.com/maps/place")]').count()
-                logging.info(f"Currently Found: {found}")
                 if found >= total:
+                    logging.info(f"Currently Found: {found}")
                     break
                 if found == previously_counted:
-                    logging.info("Arrived at all available")
-                    break
+                    stagnant_rounds += 1
+                    if stagnant_rounds >= MAX_STAGNANT_SCROLLS:
+                        logging.info(f"Arrived at all available: {found}")
+                        break
+                    # The count only settles once the lazy-loaded batch lands, so
+                    # wait before treating a flat round as the end of the list.
+                    page.wait_for_timeout(SCROLL_SETTLE_MS)
+                else:
+                    stagnant_rounds = 0
+                    logging.info(f"Currently Found: {found}")
                 previously_counted = found
             listings = page.locator('//a[contains(@href, "https://www.google.com/maps/place")]').all()[:total]
             listings = [listing.locator("xpath=..") for listing in listings]


### PR DESCRIPTION
Fixes #15.

## Problem

The scroll loop breaks as soon as one round finds the same count as the previous one:

```python
if found == previously_counted:
    logging.info("Arrived at all available")
    break
```

Google lazy-loads the results panel, so a flat round normally means the next batch is still in flight — not that the list ended. The loop spins faster than results arrive and exits almost immediately, which is what #15 reports.

## Measurement

Scroll phase only (no extraction), same query, unreachable target so both run to exhaustion:

| query | current `main` | with this patch |
|---|---|---|
| `"cafeterias en Buenos Aires"` | **22** results, 5 rounds, 0.6s | **54** results, 16 rounds, 8.6s |
| `"restaurantes en Cordoba Argentina"` | **18** results, 3 rounds, 0.4s | **72** results, 20 rounds, 9.2s |

Current `main` gives up in under a second — before the first lazy batch has even landed. Asking for `-t 50` silently gets you 22.

## Fix

Only conclude the list is exhausted after `MAX_STAGNANT_SCROLLS` consecutive flat rounds, waiting `SCROLL_SETTLE_MS` between them.

The wait is paid **only** when the count looks stagnant. Runs that keep finding results never hit it, so the hot path stays exactly as fast as today and the wait-for-element approach from #2 is preserved — no blind sleep was added to the loop. Worst case cost when the list really is exhausted is ~3s.

## Verification

End to end with `-t 50`:

```
INFO - Currently Found: 22
INFO - Currently Found: 28
INFO - Currently Found: 40
INFO - Currently Found: 43
INFO - Currently Found: 49
INFO - Currently Found: 55
INFO - Total Found: 50
INFO - Saved 49 places to result.csv (append=False)
```

49 places scraped (one listing had no name and was skipped by the existing guard), 33 with phone numbers, 35 with websites. On `main` this same command stops at the first 22.

Independent of #19 and #20 — different function, no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
